### PR TITLE
removed trailing slash from locations in navigation.yml

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -24,7 +24,7 @@ main:
     url: /join-us/
 
   - title: "Locations"
-    url: /locations/
+    url: /locations
 
   - title: "Downloads"
     url: /downloads/


### PR DESCRIPTION
@rowan-oa-munson so sorry to revert your changes but since the locations page is an html file, adding the extra slash causes the page to break :(